### PR TITLE
Add CompletionStage argument unit test

### DIFF
--- a/async/src/test/java/com/ea/async/test/CompletionStageTest.java
+++ b/async/src/test/java/com/ea/async/test/CompletionStageTest.java
@@ -57,4 +57,21 @@ public class CompletionStageTest extends BaseTest
         assertEquals(3, (int) res.toCompletableFuture().join());
     }
 
+    @Test
+    public void completionStageArgument() {
+        class Experiment
+        {
+
+            CompletionStage<Integer> doIt(CompletionStage<Integer> stage, int b) {
+                int a = await(stage);
+                return CompletableFuture.completedFuture(a + b);
+            }
+        }
+        CompletionStage<Integer> task = getBlockedTask(1);
+        CompletionStage<Integer> res = new Experiment().doIt(task, 2);
+
+        completeFutures();
+        assertEquals(3, (int) res.toCompletableFuture().join());
+    }
+    
 }


### PR DESCRIPTION
The following unit test demonstrates the `VerifyError` identified in issue #1 .  It seems to only occur if the `CompletionStage<T>` is passed to the asynchronous method as a parameter.  If the unit test calls `getBlockedTask()` within the asynchronous method and upcasts that to `CompletionStage<Integer>` the error does not occur.