### PR TITLE
Generate async methods with synthetic access modifier

### DIFF
--- a/async/src/main/java/com/ea/async/instrumentation/Transformer.java
+++ b/async/src/main/java/com/ea/async/instrumentation/Transformer.java
@@ -575,7 +575,7 @@ public class Transformer implements ClassFileTransformer
 
         final boolean staticSynchronized = ((original.access & ACC_SYNCHRONIZED) != 0 && (original.access & ACC_STATIC) != 0);
         final boolean instanceSynchronized = ((original.access & ACC_SYNCHRONIZED) != 0 && (original.access & ACC_STATIC) == 0);
-        final MethodNode continued = new MethodNode(Opcodes.ACC_PRIVATE | ACC_STATIC | (staticSynchronized ? ACC_SYNCHRONIZED : 0),
+        final MethodNode continued = new MethodNode(Opcodes.ACC_PRIVATE | ACC_STATIC | ACC_SYNTHETIC | (staticSynchronized ? ACC_SYNCHRONIZED : 0),
                 original.name, original.desc, original.signature, (String[]) original.exceptions.toArray(new String[original.exceptions.size()]));
 
         String continuedName = "async$" + original.name;


### PR DESCRIPTION
ea-async generated bytecode can create problems with tools that analyze
the java bytecode directly without looking at the source code. Usually
these tools ignore bytecode methods that are marked as synthetic since
that means it is compiler generated code not written directly by a user.

This change ensures that all methods generated are marked as synthetic,
which fixes issues with aforementioned tools.