### PR TITLE
Upgrade bytebuddy and ASM

### DIFF
--- a/async/pom.xml
+++ b/async/pom.xml
@@ -40,7 +40,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <name>EA Async-Await</name>
 
     <properties>
-        <asm.version>7.0</asm.version>
+        <asm.version>7.1</asm.version>
     </properties>
 
     <build>
@@ -133,7 +133,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>1.8.12</version>
+            <version>1.9.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Version `1.2.2` causes the following running on Amazon Corretto 11. The main reason seems to be that ByteBuddy did not support Java 11 until version 1.9.0 (https://github.com/raphw/byte-buddy/blob/master/release-notes.md). As the current version of ByteBuddy is reliant of ASM 7.1 I upgraded that dependency as well.

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000107c5ca9b, pid=7729, tid=6659
#
# JRE version: OpenJDK Runtime Environment (11.0.3+7) (build 11.0.3+7-LTS)
# Java VM: OpenJDK 64-Bit Server VM (11.0.3+7-LTS, mixed mode, tiered, compressed oops, g1 gc, bsd-amd64)
# Problematic frame:
# V  [libjvm.dylib+0x65ca9b]  ResolvedMethodTable::add_method(Handle)+0x61
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
# If you would like to submit a bug report, please visit:
#   http://bugreport.java.com/bugreport/crash.jsp
#

```