### PR TITLE
Create Gradle plugin for build-time instrumentation

### DIFF
--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -52,6 +52,14 @@
                     <failOnError>false</failOnError>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <repositories>
@@ -79,6 +87,8 @@
             <artifactId>maven-core</artifactId>
             <version>3.5.3</version>
         </dependency>
+
+        <!-- Gradle dependencies -->
 
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
@@ -110,7 +120,35 @@
 
         <dependency>
             <groupId>org.gradle</groupId>
-            <artifactId>gradle-base-services-groovy</artifactId>
+            <artifactId>gradle-model-core</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-jvm</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-language-java</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-platform-jvm</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-plugins</artifactId>
             <version>5.6.4</version>
             <scope>provided</scope>
         </dependency>
@@ -122,12 +160,7 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.maven</groupId>
-            <artifactId>maven-compat</artifactId>
-            <version>3.5.3</version>
-            <scope>test</scope>
-        </dependency>
+        <!-- Test dependency -->
 
         <dependency>
             <groupId>junit</groupId>

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -1,0 +1,139 @@
+<!--
+  Copyright (C) 2020 Electronic Arts Inc.  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+  1.  Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+  2.  Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+  3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+      its contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.ea.async</groupId>
+        <artifactId>ea-async-parent</artifactId>
+        <version>1.2.4-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <artifactId>ea-async-gradle-plugin</artifactId>
+    <packaging>jar</packaging>
+    <name>EA Async-Await Gradle Plugin</name>
+    <description>Pre-instruments class files to work with the async-await paradigm</description>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-clean-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <failOnError>false</failOnError>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <repositories>
+        <repository>
+            <id>gradle</id>
+            <name>Gradle Releases Repository</name>
+            <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
+        </repository>
+    </repositories>
+    <dependencies>
+        <dependency>
+            <groupId>com.ea.async</groupId>
+            <artifactId>ea-async</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-artifact</artifactId>
+            <version>3.5.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.5.3</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>2.5.8</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-core-api</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-base-services-groovy</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>5.6.4</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>3.5.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+</project>

--- a/gradle-plugin/pom.xml
+++ b/gradle-plugin/pom.xml
@@ -146,27 +146,5 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.gradle</groupId>
-            <artifactId>gradle-plugins</artifactId>
-            <version>5.6.4</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.gradle</groupId>
-            <artifactId>gradle-tooling-api</artifactId>
-            <version>5.6.4</version>
-            <scope>provided</scope>
-        </dependency>
-
-        <!-- Test dependency -->
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-
     </dependencies>
 </project>

--- a/gradle-plugin/src/main/java/com/ea/async/gradle/plugin/AsyncPlugin.java
+++ b/gradle-plugin/src/main/java/com/ea/async/gradle/plugin/AsyncPlugin.java
@@ -1,0 +1,43 @@
+/*
+ Copyright (C) 2020 Electronic Arts Inc.  All rights reserved.
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+ 1.  Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+ 2.  Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+ 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+     its contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.ea.async.gradle.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+
+public class AsyncPlugin implements Plugin<Project>
+{
+
+    @Override
+    public void apply(final Project project)
+    {
+
+    }
+
+}

--- a/gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.ea.async.gradle.plugin.properties
+++ b/gradle-plugin/src/main/resources/META-INF/gradle-plugins/com.ea.async.gradle.plugin.properties
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2020 Electronic Arts Inc.  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+# 3.  Neither the name of Electronic Arts, Inc. ("EA") nor the names of
+#     its contributors may be used to endorse or promote products derived
+#     from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY ELECTRONIC ARTS AND ITS CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL ELECTRONIC ARTS OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+# ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+implementation-class=com.ea.async.gradle.plugin.AsyncPlugin

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <module>async</module>
         <module>maven-plugin</module>
         <module>maven-plugin/src/test/project-to-test</module>
+        <module>gradle-plugin</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
As requested by https://github.com/electronicarts/ea-async/issues/19, this introduces a Gradle plugin module, `ea-async-gradle-plugin`. Applying this plugin to a project causes all Java compilation tasks to be followed up on by instrumentation of their output class files. This applies to *all* `JavaCompile` tasks, not just the standard ones provided by the Gradle Java plugin, so it will also work for e.g. Android builds and compose nicely with more complex workflows from other plugins. Thanks to classloader configuration, it also supports `CompletionStage` subclasses defined in the target project.

In my experience, testing Gradle plugins is unwieldy. I have created [this repo](https://github.com/Fleex255/ea-async-gradle-test) to demonstrate the usage and functionality of the plugin. The assembled plugin should be placed in the `plugin` directory named `ea-async-gradle-plugin.jar`. Suggestions are welcome on how to test this more rigorously.

To use EA Async by this plugin in a Gradle project, one would:

1. Add the plugin as a buildscript dependency. In the example project this is done by [referencing a local JAR](https://github.com/Fleex255/ea-async-gradle-test/blob/ee7b983272a13f049399422409f1c8f4d27fac59/build.gradle#L3). In a real project one would refer to an artifact on a repository like Maven Central.
2. [Apply the plugin](https://github.com/Fleex255/ea-async-gradle-test/blob/ee7b983272a13f049399422409f1c8f4d27fac59/build.gradle#L12) to the project.
3. Add the main [`ea-async` artifact as a dependency](https://github.com/Fleex255/ea-async-gradle-test/blob/ee7b983272a13f049399422409f1c8f4d27fac59/build.gradle#L24) on the project. Since the instrumentation will remove all references to `Async`, the dependency can be `compileOnly`.