### PR TITLE
Add final to Transformer::futureMap and Transformer::classLoaderMap

### DIFF
--- a/async/src/main/java/com/ea/async/instrumentation/Transformer.java
+++ b/async/src/main/java/com/ea/async/instrumentation/Transformer.java
@@ -133,8 +133,8 @@ public class Transformer implements ClassFileTransformer
             "metafactory",
             LAMBDA_DESC);
 
-    public static WeakHashMap<URL, Boolean> futureMap = new WeakHashMap<>();
-    public static WeakHashMap<ClassLoader, Set<URL>> classLoaderMap = new WeakHashMap<>();
+    public static final WeakHashMap<URL, Boolean> futureMap = new WeakHashMap<>();
+    public static final WeakHashMap<ClassLoader, Set<URL>> classLoaderMap = new WeakHashMap<>();
 
     private Consumer<String> errorListener;
 


### PR DESCRIPTION
This static field public but not final, and could be changed by malicious code or by accident from another package. The field could be made final to avoid this vulnerability.