### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/async/src/main/java/com/ea/async/Async.java
+++ b/async/src/main/java/com/ea/async/Async.java
@@ -69,6 +69,8 @@ import java.util.concurrent.CompletionStage;
  */
 public class Async
 {
+    private Async(){}
+
     /**
      * Ensure that if no pre instrumentation was done, that the Async runtime instrumentation is running.
      * <p/>

--- a/async/src/main/java/com/ea/async/Async.java
+++ b/async/src/main/java/com/ea/async/Async.java
@@ -67,7 +67,7 @@ import java.util.concurrent.CompletionStage;
  * }
  * </code></pre>
  */
-public class Async
+public final class Async
 {
     private Async(){}
 


### PR DESCRIPTION
Utility classes, which are collections of static members, are not meant to be instantiated. Even abstract utility classes, which can be extended, should not have public constructors.

Java adds an implicit public constructor to every class which does not define at least one explicitly. Hence, at least one non-public constructor should be defined.