### PR TITLE
Replace Travis CI with GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+on: [ push, pull_request ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        java: [ '8', '11', '16' ]
+
+    name: Test with Java ${{ matrix.java }}
+
+    steps:
+      - uses: actions/checkout@v2.3.4
+
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v2.1.0
+        with:
+          distribution: 'adopt-hotspot'
+          java-version: ${{ matrix.java }}
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Test with Maven
+        run: mvn -B test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: java
-sudo: false
-jdk:
-  - openjdk8
-  - openjdk11
-  - openjdk12


### PR DESCRIPTION
# Description

This replaces `.travis.yml` with `.github/workflows/test.yml` which behaves in the same way.

As for logical changes: JDK 12 was replaced with JDK 16 as it is the last non-LTS version at the moment.