### PR TITLE
Update ASM version to support Java 14

### DIFF
--- a/async/pom.xml
+++ b/async/pom.xml
@@ -40,7 +40,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <name>EA Async-Await</name>
 
     <properties>
-        <asm.version>7.1</asm.version>
+        <asm.version>8.0</asm.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Related to #52

Updates the ASM version to 8.0 in `async/pom.xml` to support Java 14 class file major version 58.
- Changes the `<asm.version>` property from `7.1` to `8.0` to ensure compatibility with Java 14.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/electronicarts/ea-async/issues/52?shareId=d522a8fa-98d1-46de-87b0-3df00b32d726).